### PR TITLE
Fixed extra spaces in annotated text

### DIFF
--- a/train.py
+++ b/train.py
@@ -24,21 +24,29 @@ def convert_dataturks_to_spacy(dataturks_JSON_FilePath):
             data = json.loads(line)
             text = data['content']
             entities = []
-            for annotation in data['annotation']:
-                #only a single point in text annotation.
-                point = annotation['points'][0]
-                labels = annotation['label']
-                # handle both list of labels or a single label.
-                if not isinstance(labels, list):
-                    labels = [labels]
+            data_annotations = data['annotation']
+            if data_annotations is not None:
+                for annotation in data_annotations:
+                    #only a single point in text annotation.
+                    point = annotation['points'][0]
+                    labels = annotation['label']
+                    # handle both list of labels or a single label.
+                    if not isinstance(labels, list):
+                        labels = [labels]
 
-                for label in labels:
-                    #dataturks indices are both inclusive [start, end] but spacy is not [start, end)
-                    entities.append((point['start'], point['end'] + 1 ,label))
-
-
+                    for label in labels:
+                        point_start = point['start']
+                        point_end = point['end']
+                        point_text = point['text']
+                        
+                        lstrip_diff = len(point_text) - len(point_text.lstrip())
+                        rstrip_diff = len(point_text) - len(point_text.rstrip())
+                        if lstrip_diff != 0:
+                            point_start = point_start + lstrip_diff
+                        if rstrip_diff != 0:
+                            point_end = point_end - rstrip_diff
+                        entities.append((point_start, point_end + 1 , label))
             training_data.append((text, {"entities" : entities}))
-
         return training_data
     except Exception as e:
         logging.exception("Unable to process " + dataturks_JSON_FilePath + "\n" + "error = " + str(e))


### PR DESCRIPTION
Added check for spaces in annotated text, and accordingly updated start and end index. 
Based on data provided on: https://dataturks.com/projects/abhishek.narayanan/Entity%20Recognition%20in%20Resumes I was getting some error due to start and end index containing leading and trailing spaces.

**Error:**
> Could not find an optimal move to supervise the parser. Usually, this means that the model can't be updated in a way that's valid and satisfies the correct annotations specified in the GoldParse. For example, are all labels added to the model? If you're training a named entity recognizer, also make sure that none of your annotated entity spans have leading or trailing whitespace. You can also use the experimental `debug-data` command to validate your
> JSON-formatted training data 